### PR TITLE
Use JediPool for redis connections

### DIFF
--- a/edc-client/build.gradle
+++ b/edc-client/build.gradle
@@ -4,7 +4,7 @@
  */
 
 group = 'com.turn'
-version = '0.1'
+version = '0.2'
 
 dependencies {
 	compile project(':edc-common')


### PR DESCRIPTION
Using JedisPool will block incoming threads for shared connections.
This also allows for increased concurrent connections.

Signed-off-by: Tommy Shiou <tshiou@turn.com>