### PR TITLE
Personal/yli/ttl

### DIFF
--- a/edc-client/build.gradle
+++ b/edc-client/build.gradle
@@ -4,7 +4,7 @@
  */
 
 group = 'com.turn'
-version = '0.3'
+version = '0.4'
 
 dependencies {
 	compile project(':edc-common')

--- a/edc-client/src/main/java/com/turn/edc/client/EDCClient.java
+++ b/edc-client/src/main/java/com/turn/edc/client/EDCClient.java
@@ -248,7 +248,7 @@ public class EDCClient {
 			throws TimeoutException, IOException, InvalidParameterException {
 		checkHostAndPort(hostAndPort);
 
-		return router.setTTL(new CacheInstance(hostAndPort, -1), key, ttl) ;
+		return router.setTTL(new CacheInstance(hostAndPort), key, ttl) ;
 	}
 
 	/**

--- a/edc-client/src/main/java/com/turn/edc/client/EDCClient.java
+++ b/edc-client/src/main/java/com/turn/edc/client/EDCClient.java
@@ -230,6 +230,26 @@ public class EDCClient {
 
 		router.store(new CacheInstance(destination), new StoreRequest(key, subkey, value, ttl));
 	}
+	
+	/**
+	 * Set the ttl for a key in the provided destination
+	 *
+	 * @param destination Destination host and port
+	 * @param key Top-level key
+	 * @param ttl TTL (in seconds) for the top-level key
+	 * 
+	 * @return whether setTTL operation fail or succeed
+	 *
+	 * @throws IOException 
+	 * @throws TimeoutException 
+	 * @throws InvalidParameterException 
+	 */
+	public boolean setTTL(HostAndPort hostAndPort, String key, int ttl)
+			throws TimeoutException, IOException, InvalidParameterException {
+		checkHostAndPort(hostAndPort);
+
+		return router.setTTL(new CacheInstance(hostAndPort, -1), key, ttl) ;
+	}
 
 	/**
 	 * Checks if the hostAndPort is valid (host is not empty, and port is > 0)

--- a/edc-client/src/main/java/com/turn/edc/router/RequestRouter.java
+++ b/edc-client/src/main/java/com/turn/edc/router/RequestRouter.java
@@ -87,7 +87,7 @@ public class RequestRouter extends DiscoveryListener {
 	}
 	
 	public boolean setTTL(CacheInstance destination, String key, int ttl) 
-			throws KeyNotFoundException, TimeoutException, IOException{
+			throws TimeoutException, IOException{
 
 		StorageConnection connection = routingMap.get(destination.hashCode());
 

--- a/edc-client/src/main/java/com/turn/edc/storage/ConnectionFactory.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/ConnectionFactory.java
@@ -62,6 +62,11 @@ public class ConnectionFactory {
 				public byte[] get(String key, String subkey, int timeout) throws KeyNotFoundException, TimeoutException, IOException {
 					return new byte[0];
 				}
+				
+				@Override
+				public boolean setTTL(String key, int ttl, int timeout) throws IOException {
+					return false;
+				}
 
 				@Override
 				public void close() {

--- a/edc-client/src/main/java/com/turn/edc/storage/StorageConnection.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/StorageConnection.java
@@ -43,7 +43,7 @@ public class StorageConnection {
 	}
 	
 	public boolean setTTL(String key, int ttl, int timeOut)
-			throws KeyNotFoundException, TimeoutException, IOException {
+			throws TimeoutException, IOException {
 		return this.connector.setTTL(key, ttl, timeOut);
 	}
 

--- a/edc-client/src/main/java/com/turn/edc/storage/StorageConnection.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/StorageConnection.java
@@ -5,6 +5,7 @@
 
 package com.turn.edc.storage;
 
+import com.turn.edc.discovery.CacheInstance;
 import com.turn.edc.exception.KeyNotFoundException;
 import com.turn.edc.router.StoreRequest;
 
@@ -39,6 +40,11 @@ public class StorageConnection {
 
 	public void post(StoreRequest request) {
 		this.storeRequestBus.post(request);
+	}
+	
+	public boolean setTTL(String key, int ttl, int timeOut)
+			throws KeyNotFoundException, TimeoutException, IOException {
+		return this.connector.setTTL(key, ttl, timeOut);
 	}
 
 	public void close() {

--- a/edc-client/src/main/java/com/turn/edc/storage/StorageConnector.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/StorageConnector.java
@@ -46,9 +46,4 @@ public abstract class StorageConnector {
 			LOG.debug(ExceptionUtils.getStackTrace(e));
 		}
 	}
-
-	public void setTTL(String key, int timeout) throws KeyNotFoundException, TimeoutException, IOException {
-		// TODO Auto-generated method stub
-		
-	}
 }

--- a/edc-client/src/main/java/com/turn/edc/storage/StorageConnector.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/StorageConnector.java
@@ -31,6 +31,8 @@ public abstract class StorageConnector {
 	public abstract byte[] get(String key, int timeout) throws KeyNotFoundException, TimeoutException, IOException;
 
 	public abstract byte[] get(String key, String subkey, int timeout) throws KeyNotFoundException, TimeoutException, IOException;
+	
+	public abstract boolean setTTL(String key, int ttl, int timeout) throws IOException;
 
 	public abstract void close();
 
@@ -43,5 +45,10 @@ public abstract class StorageConnector {
 			LOG.error("Store request failed to {}", this.toString());
 			LOG.debug(ExceptionUtils.getStackTrace(e));
 		}
+	}
+
+	public void setTTL(String key, int timeout) throws KeyNotFoundException, TimeoutException, IOException {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/edc-client/src/main/java/com/turn/edc/storage/impl/SpymemcachedStorageConnector.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/impl/SpymemcachedStorageConnector.java
@@ -57,6 +57,11 @@ public class SpymemcachedStorageConnector extends StorageConnector {
 	public byte[] get(String key, String subkey, int timeout) throws KeyNotFoundException, TimeoutException, IOException {
 		return (byte[]) client.get(key + ":" + subkey);
 	}
+	
+	@Override
+	public boolean setTTL(String key, int ttl, int timeout) throws IOException {
+		return false;
+	}
 
 	@Override
 	public void close() {


### PR DESCRIPTION
Redis support expire function 
input parameter : String key, int seconds
output parameter:  1: the timeout was set. 0: the timeout was not set since the key already has an associated timeout (this may happen only in Redis versions &lt;
   *         2.1.3, Redis &gt;= 2.1.3 will happily update the timeout), or the key does not exist.