### PR TITLE
Async Redis storage for EDCClient builder

### DIFF
--- a/edc-client/build.gradle
+++ b/edc-client/build.gradle
@@ -4,7 +4,7 @@
  */
 
 group = 'com.turn'
-version = '0.5'
+version = '0.5.1'
 
 dependencies {
 	compile project(':edc-common')

--- a/edc-client/src/main/java/com/turn/edc/client/EDCClient.java
+++ b/edc-client/src/main/java/com/turn/edc/client/EDCClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Turn Inc. All Rights Reserved.
+ * Copyright (C) 2016-2017 Turn Inc. All Rights Reserved.
  * Proprietary and confidential.
  */
 
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
+import com.google.common.eventbus.SubscriberExceptionHandler;
 import com.google.common.net.HostAndPort;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -309,14 +310,21 @@ public class EDCClient {
 
 			EDCStorageBuilder() {}
 
-			public EDCServiceDiscoveryBuilder usingRedisStorage() {
+			public EDCServiceDiscoveryBuilder usingRedisStorage(SubscriberExceptionHandler subscriberExceptionHandler) {
 				return new EDCServiceDiscoveryBuilder(
-						new ConnectionFactory(StorageType.REDIS)	);
+						new ConnectionFactory(StorageType.REDIS, subscriberExceptionHandler));
 			}
 
-			public EDCServiceDiscoveryBuilder usingMemcachedStorage() {
+			public EDCServiceDiscoveryBuilder usingAsyncRedisStorage(
+					SubscriberExceptionHandler subscriberExceptionHandler, int queueSize) {
 				return new EDCServiceDiscoveryBuilder(
-						new ConnectionFactory(StorageType.MEMCACHED));
+						new ConnectionFactory(StorageType.REDIS, subscriberExceptionHandler, queueSize));
+			}
+
+			public EDCServiceDiscoveryBuilder usingMemcachedStorage(
+					SubscriberExceptionHandler subscriberExceptionHandler) {
+				return new EDCServiceDiscoveryBuilder(
+						new ConnectionFactory(StorageType.MEMCACHED, subscriberExceptionHandler));
 			}
 		}
 

--- a/edc-client/src/main/java/com/turn/edc/router/RequestRouter.java
+++ b/edc-client/src/main/java/com/turn/edc/router/RequestRouter.java
@@ -106,7 +106,7 @@ public class RequestRouter extends DiscoveryListener {
 				try {
 					newConnection = connectorFactory.create(
 							instance.getHostAndPort().getHostText(),
-							Integer.toString(instance.getHostAndPort().getPort()),
+							instance.getHostAndPort().getPort(),
 							TIMEOUT
 					);
 					newRoutingMap.put(instance.hashCode(), newConnection);
@@ -159,7 +159,7 @@ public class RequestRouter extends DiscoveryListener {
 			try {
 				connection = connectorFactory.create(
 						source.getHostAndPort().getHostText(),
-						Integer.toString(source.getHostAndPort().getPort()),
+						source.getHostAndPort().getPort(),
 						TIMEOUT
 				);
 			} catch (IOException ioe) {

--- a/edc-client/src/main/java/com/turn/edc/storage/StorageConnector.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/StorageConnector.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.eventbus.Subscribe;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,13 +36,8 @@ public abstract class StorageConnector {
 	public abstract void close();
 
 	@Subscribe
-	public void handleStoreRequest(StoreRequest request) {
+	public void handleStoreRequest(StoreRequest request) throws IOException {
 		LOG.debug("Storing {}", request.toString());
-		try {
-			this.set(request.getKey(), request.getSubkey(), request.getPayload(), request.getTtl(), 10);
-		} catch (IOException e) {
-			LOG.error("Store request failed to {}", this.toString());
-			LOG.debug(ExceptionUtils.getStackTrace(e));
-		}
+		this.set(request.getKey(), request.getSubkey(), request.getPayload(), request.getTtl(), 10);
 	}
 }

--- a/edc-client/src/main/java/com/turn/edc/storage/impl/JedisStorageConnector.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/impl/JedisStorageConnector.java
@@ -40,10 +40,10 @@ public class JedisStorageConnector extends StorageConnector {
 	// Weak reference since most of the time we don't need the string representation
 	private WeakReference<String> toString = new WeakReference<>(null);
 
-	public JedisStorageConnector(String host, String port, int timeout) throws IOException {
+	public JedisStorageConnector(String host, int port, int timeout) throws IOException {
 
 		this.host = host;
-		this.port = Integer.parseInt(port);
+		this.port = port;
 		JedisPoolConfig config = new JedisPoolConfig();
 		// TODO: make these configurable
 		config.setMaxWaitMillis(100);
@@ -55,7 +55,7 @@ public class JedisStorageConnector extends StorageConnector {
 		this.jedisPool = new JedisPool(config, this.host, this.port, 0, timeout, null, Protocol.DEFAULT_DATABASE, null);
 
 		// Try pinging once
-		try (Jedis jedis = jedisPool.getResource()){
+		try (Jedis jedis = jedisPool.getResource()) {
 			if (!jedis.ping().equals("PONG")) {
 				throw new IOException("Could not reach redis instance: " + toString());
 			}
@@ -74,7 +74,7 @@ public class JedisStorageConnector extends StorageConnector {
 		}
 
 		// Jedis instance will be auto-returned to the pool
-		try (Jedis jedis = jedisPool.getResource()){
+		try (Jedis jedis = jedisPool.getResource()) {
 			// Test connectivity, this is cheaper than a full validation (i.e. ping)
 			if (!jedis.isConnected()) {
 				jedis.connect();
@@ -101,7 +101,7 @@ public class JedisStorageConnector extends StorageConnector {
 		}
 
 		// Jedis instance will be auto-returned to the pool
-		try (Jedis jedis = jedisPool.getResource()){
+		try (Jedis jedis = jedisPool.getResource()) {
 			// Test connectivity, this is cheaper than a full validation (i.e. ping)
 			if (!jedis.isConnected()) {
 				jedis.connect();
@@ -155,4 +155,13 @@ public class JedisStorageConnector extends StorageConnector {
 		}
 		return this.toString.get();
 	}
+
+	public String getHost() {
+		return this.host;
+	}
+
+	public int getPort() {
+		return this.port;
+	}
+
 }

--- a/edc-client/src/main/java/com/turn/edc/storage/impl/SpymemcachedStorageConnector.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/impl/SpymemcachedStorageConnector.java
@@ -23,9 +23,13 @@ import net.spy.memcached.MemcachedClient;
 public class SpymemcachedStorageConnector extends StorageConnector {
 
 	private final MemcachedClient client;
+	private final String host;
+	private final int port;
 
-	public SpymemcachedStorageConnector(String host, String port, int timeout) throws IOException {
-		this.client = new MemcachedClient(new InetSocketAddress(host, Integer.parseInt(port)));
+	public SpymemcachedStorageConnector(String host, int port, int timeout) throws IOException {
+		this.host = host;
+		this.port = port;
+		this.client = new MemcachedClient(new InetSocketAddress(this.host, this.port));
 		// TODO: Sanity check host and port
 	}
 
@@ -67,4 +71,13 @@ public class SpymemcachedStorageConnector extends StorageConnector {
 	public void close() {
 
 	}
+
+	public String getHost() {
+		return this.host;
+	}
+
+	public int getPort() {
+		return this.port;
+	}
+
 }


### PR DESCRIPTION
EDCClient.builder be able to build clients with async Redis storage and with custom exception handler

Jira: RUN-1639
Signed-off-by: Daniel Liu <daniel.liu@turn.com>