### PR TITLE
Fix cross DC connecitons issue

### DIFF
--- a/edc-client/build.gradle
+++ b/edc-client/build.gradle
@@ -4,7 +4,7 @@
  */
 
 group = 'com.turn'
-version = '0.5.4'
+version = '0.5.5'
 
 configurations.all {
     resolutionStrategy {

--- a/edc-client/src/main/java/com/turn/edc/storage/ConnectionFactory.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/ConnectionFactory.java
@@ -77,6 +77,16 @@ public class ConnectionFactory {
 			new StorageConnector() {
 
 				@Override
+				public void initialize() throws IOException {
+
+				}
+
+				@Override
+				public boolean isInitialized() {
+					return true;
+				}
+
+				@Override
 				public void set(String key, byte[] value, int ttl, int timeout) throws IOException {
 
 				}

--- a/edc-client/src/main/java/com/turn/edc/storage/StorageConnection.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/StorageConnection.java
@@ -29,6 +29,11 @@ public class StorageConnection {
 	private final StorageConnector connector;
 	private final EventBus storeRequestBus;
 
+	private StorageConnection(){
+		this.connector = null;
+		this.storeRequestBus = null;
+	}
+
 	public StorageConnection(StorageConnector connector, SubscriberExceptionHandler subscriberExceptionHandler,
 			boolean async, int asyncQueueCapacity) {
 		this.connector = connector;
@@ -39,6 +44,14 @@ public class StorageConnection {
 								asyncQueueCapacity > 0 ? asyncQueueCapacity : Integer.MAX_VALUE)),
 				subscriberExceptionHandler) : new EventBus(subscriberExceptionHandler);
 		this.storeRequestBus.register(connector);
+	}
+
+	public void connect() throws IOException {
+		this.connector.initialize();
+	}
+
+	public boolean isConnected() {
+		return this.connector.isInitialized();
 	}
 
 	public byte[] get(String key, String subkey, int timeout) throws IOException, TimeoutException, KeyNotFoundException {

--- a/edc-client/src/main/java/com/turn/edc/storage/StorageConnector.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/StorageConnector.java
@@ -23,6 +23,10 @@ import org.slf4j.LoggerFactory;
 public abstract class StorageConnector {
 	private static final Logger LOG = LoggerFactory.getLogger(StorageConnector.class);
 
+	public abstract void initialize() throws IOException;
+
+	public abstract boolean isInitialized();
+
 	public abstract void set(String key, byte[] value, int ttl, int timeout) throws IOException;
 
 	public abstract void set(String key, String subkey, byte[] value, int ttl, int timeout) throws IOException;

--- a/edc-client/src/main/java/com/turn/edc/storage/impl/SpymemcachedStorageConnector.java
+++ b/edc-client/src/main/java/com/turn/edc/storage/impl/SpymemcachedStorageConnector.java
@@ -22,17 +22,32 @@ import net.spy.memcached.MemcachedClient;
  */
 public class SpymemcachedStorageConnector extends StorageConnector {
 
-	private final MemcachedClient client;
 	private final String host;
 	private final int port;
 
-	public SpymemcachedStorageConnector(String host, int port, int timeout) throws IOException {
+	private boolean isInitialzed;
+	private MemcachedClient client;
+
+	public SpymemcachedStorageConnector(String host, int port, int timeout) {
 		this.host = host;
 		this.port = port;
-		this.client = new MemcachedClient(new InetSocketAddress(this.host, this.port));
+
 		// TODO: Sanity check host and port
 	}
 
+	@Override
+	public void initialize() throws IOException {
+		if (isInitialized()) {
+			return;
+		}
+		this.client = new MemcachedClient(new InetSocketAddress(this.host, this.port));
+		isInitialzed = true;
+	}
+
+	@Override
+	public boolean isInitialized() {
+		return isInitialzed;
+	}
 
 	@Override
 	public void set(String key, byte[] value, int ttl, int timeout) throws IOException {


### PR DESCRIPTION
In RequestRouter, we maintain a connection pool for all connected edc hosts. Connections
in this pool are lazy loaded. However, 10 ms timeout caused lots of cross continent connection
time out or stuck. Lack of protection on this connection pool, a lot of client threads would try
to create tens of connections to the same edc host at the same time and time out, which cause
a large number of dead threads.

Signed-off-by: Jin-cheng Chen <Jin-cheng.Chen@turn.com>